### PR TITLE
Add support for MQTTS certificates

### DIFF
--- a/alexa.html
+++ b/alexa.html
@@ -10,7 +10,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<script type="text/x-red" data-template-name="alexa-smart-home-v3-conf">
+<script type="text/html" data-template-name="alexa-smart-home-v3-conf">
      <div class="form-row">
       <label for="node-config-input-username" style="width:130px"><i class="icon-tag"></i> Username</label>
       <input type="text" id="node-config-input-username">
@@ -18,24 +18,40 @@
   <div class="form-row">
      	<label for="node-config-input-password" style="width:130px"><i class="icon-tag"></i> Password</label>
       <input type="password" id="node-config-input-password">
-     </div>
-     <div class="form-row">
-         <label for="node-config-input-mqttserver" style="width:130px"><i class="icon-tag"></i> MQTT Hostname</label>
-         <input type="text" id="node-config-input-mqttserver">
-     </div>
-     <div class="form-row">
-         <label for="node-config-input-webapiurl" style="width:130px"><i class="icon-tag"></i> Web API Hostname</label>
-         <input type="text" id="node-config-input-webapiurl">
-     </div>
-     <div class="form-row" title="Select the Node-RED context store to use with this Node.">
-         <label for="node-config-input-contextName" style="width:130px"><i class="icon-tag"></i> Context Store</label>
-         <select id="node-config-input-contextName"></select>
-         <div id="contextName-hint"></div>
-         <br />
-         <div class="form-tips">
-             This node requires a Node-RED memory-based <a href='https://nodered.org/docs/user-guide/context' target="_blank">context store</a>.
-         </div>
-     </div>
+  </div>
+  <div class="form-row">
+      <label for="node-config-input-mqttserver" style="width:130px"><i class="icon-tag"></i> MQTT Hostname</label>
+      <input type="text" id="node-config-input-mqttserver">  
+  </div>
+  <div class="form-row">   
+      <label for="node-config-input-mqttport" style="width:130px"><i class="icon-tag"></i> MQTT Port</label>
+      <input type="text" id="node-config-input-mqttport" placeholder="1883">
+  </div>
+  <div class="form-row">   
+    <label for="node-config-input-mqttca" style="width:130px"><i class="icon-tag"></i> MQTT CA</label>
+    <input type="text" id="node-config-input-mqttca" placeholder="optional, only for mqtts">
+  </div>
+  <div class="form-row">   
+    <label for="node-config-input-mqttcert" style="width:130px"><i class="icon-tag"></i> MQTT Cert</label>
+    <input type="text" id="node-config-input-mqttcert" placeholder="optional, only for mqtts">
+  </div>
+  <div class="form-row">   
+    <label for="node-config-input-mqttkey" style="width:130px"><i class="icon-tag"></i> MQTT Key</label>
+    <input type="text" id="node-config-input-mqttkey" placeholder="optional, only for mqtts">
+  </div>
+  <div class="form-row">
+      <label for="node-config-input-webapiurl" style="width:130px"><i class="icon-tag"></i> Web API Hostname</label>
+      <input type="text" id="node-config-input-webapiurl">
+  </div>
+  <div class="form-row" title="Select the Node-RED context store to use with this Node.">
+      <label for="node-config-input-contextName" style="width:130px"><i class="icon-tag"></i> Context Store</label>
+      <select id="node-config-input-contextName"></select>
+      <div id="contextName-hint"></div>
+      <br />
+      <div class="form-tips">
+          This node requires a Node-RED memory-based <a href='https://nodered.org/docs/user-guide/context' target="_blank">context store</a>.
+      </div>
+  </div>
 </script>
 
 <script type="text/x-red" data-help-name="alexa-smart-home-v3-conf">
@@ -50,6 +66,10 @@
     defaults: {
       username: {},
       mqttserver: { value: "mq-red.cb-net.co.uk" },
+      mqttport: { value: "1883" },
+      mqttca: { },
+      mqttcert: { },
+      mqttkey: { },
       webapiurl: { value: "red.cb-net.co.uk" },
       contextName: { value: "default" },
     },
@@ -387,10 +407,7 @@
 
 <!-- ############################################################################################## -->
 
-<script
-  type="text/x-red"
-  data-template-name="alexa-smart-home-v3-resp"
-></script>
+<script type="text/x-red" data-template-name="alexa-smart-home-v3-resp"></script>
 
 <script type="text/x-red" data-help-name="alexa-smart-home-v3-resp">
   <p>This node sends a response to Alexa to acknowledge if the command

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-alexa-smart-home",
-  "version": "0.4.68",
+  "version": "0.5.0",
   "description": "Integrate Alexa and Google Assistant / Google Home in your Node-RED flows.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     }
   },
   "author": "chrismbradford@gmail.com",
+  "contributors": [
+    "naimo84 <git@naimo84.dev>"
+  ],
   "license": "Apache-2.0",
   "dependencies": {
     "body-parser": "^1.19.0",


### PR DESCRIPTION
Hey @coldfire84,

I'd like to share my small feature "Add support for MQTTS certificates" with you. Background, why I implemented this: I'm hosting your great Alexa Home Skill on my own server within kubernetes. As I don't wanna transfer my mqtt message via unencrypted mqtt, I decided to setup the MQTT Server with a TLS config :) Therefore the new properties are needed. Also because of k8s, I needed an opportunity to use an different port than 1883 or 8883. Of course I could use my LoadBalancer Config to bind to 1883, but out of simplicity I'm gonna use a NodePort :D

TL;DR
I hope it's ok for you, that I coded this on my own ;) It was an interesting journey on how k8s, mqtt and alexa smart home skill works 👍 

Greets,
Benjamin